### PR TITLE
removed unneeded margin-top

### DIFF
--- a/src/components/cookie-consent/cookie-consent.scss
+++ b/src/components/cookie-consent/cookie-consent.scss
@@ -114,12 +114,6 @@
 		flex: auto;
 	}
 }
-@include at($screen-sm) {
-  .m-modal {
-		margin-top: 50%;
-	}
-}
-
 
 // Flexboxgrid classes
 .row {


### PR DESCRIPTION
The modal is already being centered with display:flex in the parent.
This css line was creating a scrollbar that should not be there.