### PR TITLE
rework setting and checking of categories

### DIFF
--- a/src/components/cookie-consent/cookie-consent.tsx
+++ b/src/components/cookie-consent/cookie-consent.tsx
@@ -88,6 +88,7 @@ export class CookieConsent {
 			cookiePreferences = JSON.parse(Cookies.get('cookiepreferences_' + this.currentEnvironment));
 		}
 		this.checkedCategories.forEach(function (category) {
+			// Make sure cookies from the same subdomain are left untouched
 			const index = cookiePreferences.map(e => e.category).indexOf(category.name);
 			if(index > -1) {
 				cookiePreferences[index].accepted = (type === 'all' ? true : category.enabled);

--- a/src/components/cookie-consent/cookie-consent.tsx
+++ b/src/components/cookie-consent/cookie-consent.tsx
@@ -84,11 +84,19 @@ export class CookieConsent {
 
 	setCookie(type?: string) {
 		let cookiePreferences = [];
+		if (Cookies.get('cookiepreferences_' + this.currentEnvironment)) {
+			cookiePreferences = JSON.parse(Cookies.get('cookiepreferences_' + this.currentEnvironment));
+		}
 		this.checkedCategories.forEach(function (category) {
-			cookiePreferences = [...cookiePreferences, {
-				category: category.name,
-				accepted: (type === 'all' ? true : category.enabled)
-			}];
+			const index = cookiePreferences.map(e => e.category).indexOf(category.name);
+			if(index > -1) {
+				cookiePreferences[index].accepted = (type === 'all' ? true : category.enabled);
+			} else {
+				cookiePreferences = [...cookiePreferences, {
+					category: category.name,
+					accepted: (type === 'all' ? true : category.enabled)
+				}];
+			}
 		})
 		Cookies.set('cookiepreferences_' + this.currentEnvironment,
 			cookiePreferences,
@@ -100,17 +108,20 @@ export class CookieConsent {
 	}
 
 	checkCookie() {
+		let hideWindow = false;
 		if (Cookies.get('cookiepreferences_' + this.currentEnvironment)) {
-			this.hidden = true;
 			let cookiePreferences = JSON.parse(Cookies.get('cookiepreferences_' + this.currentEnvironment));
-
 			let checkedCategories = [...this.checkedCategories];
 			cookiePreferences.forEach(function (cookiePref) {
 				let index = checkedCategories.findIndex((obj => obj.name === cookiePref.category));
-				checkedCategories[index].enabled = cookiePref.accepted;
+				if(checkedCategories[index]){
+					hideWindow = true;
+					checkedCategories[index].enabled = cookiePref.accepted;
+				}
 			});
 			this.checkedCategories = checkedCategories;
 		}
+		this.hidden = hideWindow;
 	}
 
 	openCookiePreferences() {


### PR DESCRIPTION
Er werd geen rekening gehouden met het feit dat je op andere subsites binnen antwerpen.be een andere config met andere categorieën kan hebben. Als je met een cookie waarin categorieën zitten die niet bestaan binnen de config, crashte de cookie consent.
Hiervoor zit de fix in deze PR.

De cookievoorkeuren werden ook voor elke save leeggemaakt, waardoor categorieën die op een andere subsite werden opgeslagen verloren gingen. Hiervoor zit ook een fix in deze PR dat deze worden behouden en enkel de categorieën die je met de sliders aanpast zullen mee aangepast worden.