### PR TITLE
Feature/wcag compliance updates

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,3 +1,3 @@
-<link rel="stylesheet" href="https://cdn.antwerpen.be/core_branding_scss/5.0.1/main.min.css" />
+<link rel="stylesheet" href="https://cdn.antwerpen.be/core_branding_scss/5.0.2/main.min.css" />
 <script type="module" src="./acpaas-ui/acpaas-ui.esm.js"></script>
 <script nomodule="" src="./acpaas-ui/acpaas-ui.js"></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -7710,6 +7710,14 @@
             "integrity": "sha512-LI7v2mH02R55SekHYdv9pRHR9RajVNyIJ2N5IEkWbg7FT5ZmJ9Hw4mWxHeEUcd+dJo0QmzztHvDvWcc7prVFsw==",
             "dev": true
         },
+        "focus-trap": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.0.0.tgz",
+            "integrity": "sha512-uT4Bl8TwU+5vVAx/DHil/1eVS54k9unqhK/vGy2KSh7esPmqgC0koAB9J2sJ+vtj8+vmiFyGk2unLkhNLQaxoA==",
+            "requires": {
+                "tabbable": "^6.0.0"
+            }
+        },
         "for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -14705,6 +14713,11 @@
                 "es-abstract": "^1.17.0-next.1",
                 "has-symbols": "^1.0.1"
             }
+        },
+        "tabbable": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.0.0.tgz",
+            "integrity": "sha512-SxhZErfHc3Yozz/HLAl/iPOxuIj8AtUw13NRewVOjFW7vbsqT1f3PuiHrPQbUkRcLNEgAedAv2DnjLtzynJXiw=="
         },
         "tapable": {
             "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
         "@a-ui/core": "^5.0.0",
         "@a-ui/flexboxgrid": "^2.0.0",
         "classnames": "^2.2.6",
+        "focus-trap": "^7.0.0",
         "js-cookie": "^2.2.1",
         "react-device-detect": "^1.11.14"
     }

--- a/src/components/cookie-consent/cookie-category/cookie-category.tsx
+++ b/src/components/cookie-consent/cookie-category/cookie-category.tsx
@@ -19,10 +19,6 @@ export class CookieCategory {
 				case "category":
 					this.onOpenCloseCategory(index)
 					break;
-				case "toggle":
-					e.target.checked = !e.target.checked;
-					this.onCheckCategory(index, e);
-					break;
 			}
 		}
 	};
@@ -49,8 +45,7 @@ export class CookieCategory {
 									id={"switch-" + item.name}
 									role="switch"
 									aria-checked={item.enabled.toString()}
-									onClick={(e) => this.onCheckCategory(this.index, e)}
-									onKeyDown={(e) => this.onKeyPress(e, "toggle", this.index)}>
+									onClick={() => this.onCheckCategory(this.index)}>
 									<span class="a-switch__off">
 										{((item.showSwitch && !isMobile) && ((item.enabled ? "In" : "Uit") + "geschakeld"))}
 									</span>

--- a/src/components/cookie-consent/cookie-consent.tsx
+++ b/src/components/cookie-consent/cookie-consent.tsx
@@ -47,8 +47,10 @@ export class CookieConsent {
 	}
 
 	componentDidLoad() {
-		const focusTrap = createFocusTrap(this.componentRef);
-		setTimeout(() => focusTrap.activate());
+		if(!this.configData.nonBlocking) {
+			const focusTrap = createFocusTrap(this.componentRef);
+			setTimeout(() => focusTrap.activate());
+		}
 	}
 
 	@Watch('config')

--- a/src/components/cookie-consent/cookie-consent.tsx
+++ b/src/components/cookie-consent/cookie-consent.tsx
@@ -1,6 +1,7 @@
 import { Component, Prop, Host, State, Watch, h } from '@stencil/core';
 import Cookies from 'js-cookie';
 import { isMobile } from 'react-device-detect';
+import { createFocusTrap } from 'focus-trap';
 import classNames from 'classnames';
 
 
@@ -35,6 +36,7 @@ export class CookieConsent {
 	@State() currentEnvironment: string;
 	@State() openedManually: boolean = false;
 
+	componentRef!: HTMLElement;
 	modalRef!: HTMLElement;
 
 	componentWillLoad() {
@@ -42,6 +44,11 @@ export class CookieConsent {
 		this.checkEnvironment();
 		this.checkCookie();
 		this.checkExcludedPaths();
+	}
+
+	componentDidLoad() {
+		const focusTrap = createFocusTrap(this.componentRef);
+		setTimeout(() => focusTrap.activate());
 	}
 
 	@Watch('config')
@@ -259,7 +266,7 @@ export class CookieConsent {
 		}
 
 		return (
-			<Host class={this.branding} role='alert'>
+			<Host class={this.branding} tabindex="-1" role='dialog' aria-label="cookiemelding" aria-modal="true" ref={(el) => this.componentRef = el as HTMLElement}>
 				<div class={overlayClass}>
 					<div class='m-overlay__inner cookieconsent'>
 						<div class="m-modal m-modal--large" tabindex={0} ref={(el) => this.modalRef = el as HTMLElement}>

--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0">
   <title>ACPaaS UI Web components playground</title>
 
-  <link rel="stylesheet" href="https://cdn.antwerpen.be/core_branding_scss/5.0.1/main.min.css">
+  <link rel="stylesheet" href="https://cdn.antwerpen.be/core_branding_scss/5.0.2/main.min.css">
 
   <script type="module" src="/build/acpaas-ui.esm.js"></script>
   <script nomodule src="/build/acpaas-ui.js"></script>


### PR DESCRIPTION
Changes requested in following tickets:
https://jira.antwerpen.be/browse/WCAG-85
https://jira.antwerpen.be/browse/WCAG-89

**Changes explained:**
This PR is mainly to improve the WCAG compliance. The cookie consent modal will always be focused if it is visible. A focus trap was added to prevent users to be able to scroll through the content of the page after tabbing through the modal. 

Removed the onKeyDown event for the switch buttons. Pressing enter while focused on the button already worked without the event and because of this the event was fired 2 times causing the switch to enable and disable again. Now the switch buttons work properly while pressing enter on the keyboard.